### PR TITLE
update-normalizing-tag-branch-logic

### DIFF
--- a/src/main/java/io/codeclou/jenkins/githubwebhookbuildtriggerplugin/EnvironmentContributionAction.java
+++ b/src/main/java/io/codeclou/jenkins/githubwebhookbuildtriggerplugin/EnvironmentContributionAction.java
@@ -7,10 +7,7 @@ package io.codeclou.jenkins.githubwebhookbuildtriggerplugin;
 import hudson.EnvVars;
 import hudson.model.*;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /*
  * Inject Environment Variables into the triggered job
@@ -21,8 +18,8 @@ public class EnvironmentContributionAction implements EnvironmentContributingAct
     private transient String envVarInfo;
 
     public EnvironmentContributionAction(GithubWebhookPayload payload) {
-        String normalizedBranch = this.normalizeBranchNameOrEmptyString(payload.getRef());
-        String normalizedTag = this.normalizeTagNameOrEmptyString(payload.getRef());
+        String normalizedBranch = this.normalizeBranchNameOrEmptyString(payload);
+        String normalizedTag = this.normalizeTagNameOrEmptyString(payload);
         StringBuilder info = new StringBuilder();
         info.append("   ref\n      -> $GWBT_REF            : ").append(payload.getRef()).append("\n");
         info.append("      -> $GWBT_TAG            : ").append(normalizedTag).append("\n");
@@ -46,23 +43,31 @@ public class EnvironmentContributionAction implements EnvironmentContributingAct
     }
 
     /*
-     * converts "refs/heads/develop" to "develop"
-     */
-    private String normalizeBranchNameOrEmptyString(String branchname) {
-        if (branchname != null && branchname.startsWith("refs/heads/")) {
-            return branchname.replace("refs/heads/", "");
-        }
-        return "";
+    * converts "refs/heads/develop" to "develop"
+    */
+    private String normalizeBranchNameOrEmptyString(GithubWebhookPayload payload) {
+    //        if (branchname != null && branchname.startsWith("refs/heads/")) {
+    //            return branchname.replace("refs/heads/", "");
+    //        }
+    //        return "";
+    return Optional.ofNullable(payload)
+        .filter(hook -> hook.getRef_type().equals("branch"))
+        .map(GithubWebhookPayload::getRef)
+        .orElse("");
     }
 
     /*
-     * converts "refs/tags/1.0.0" to "1.0.0"
-     */
-    private String normalizeTagNameOrEmptyString(String tagname) {
-        if (tagname != null && tagname.startsWith("refs/tags/")) {
-            return tagname.replace("refs/tags/", "");
-        }
-        return "";
+    * converts "refs/tags/1.0.0" to "1.0.0"
+    */
+    private String normalizeTagNameOrEmptyString(GithubWebhookPayload payload) {
+    //        if (tagname != null && tagname.startsWith("refs/tags/")) {
+    //            return tagname.replace("refs/tags/", "");
+    //        }
+    //        return "";
+    return Optional.ofNullable(payload)
+        .filter(hook -> hook.getRef_type().equals("tag"))
+        .map(GithubWebhookPayload::getRef)
+        .orElse("");
     }
 
     protected String getEnvVarInfo() {

--- a/src/main/java/io/codeclou/jenkins/githubwebhookbuildtriggerplugin/GithubWebhookPayload.java
+++ b/src/main/java/io/codeclou/jenkins/githubwebhookbuildtriggerplugin/GithubWebhookPayload.java
@@ -16,12 +16,21 @@ public class GithubWebhookPayload {
      */
     private Long hook_id;
     private String ref;
+    private String ref_type;
     private String before;
     private String after;
     private GithubWebhookPayloadRepository repository;
 
     public GithubWebhookPayload() {
 
+    }
+
+    public String getRef_type() {
+        return ref_type;
+    }
+
+    public void setRef_type(String ref_type) {
+        this.ref_type = ref_type;
     }
 
     public String getRef() {


### PR DESCRIPTION
Hi, 

I noticed that GitHub changes the content of `ref` field in webhook payload:
<img width="734" alt="screen shot 2017-11-23 at 17 19 22" src="https://user-images.githubusercontent.com/2764992/33165764-f26bff7a-d072-11e7-8cbf-3604f6dda1ea.png">
<img width="660" alt="screen shot 2017-11-23 at 17 20 28" src="https://user-images.githubusercontent.com/2764992/33165769-f524b8ba-d072-11e7-86b2-6da53934c0c9.png">

So I made some changes in both `normalizeBranchNameOrEmptyString()` and `normalizeTagNameOrEmptyString()`